### PR TITLE
add in requirements to support SNI w/ python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ furl==0.3.95
 grequests==0.2.0
 dateutils==0.6.6
 bleach==1.4.1
+pyOpenSSL==0.15.1
+ndg-httpsclient==0.4.0


### PR DESCRIPTION
ref: https://github.com/kennethreitz/requests/issues/749#issuecomment-19187417

Adds in support for TLS+SNI, which is used by our Cloudfront CDN distribution with a custom CNAME.