### PR TITLE
Issue 329 adapt upstream changes

### DIFF
--- a/splice/default_settings.py
+++ b/splice/default_settings.py
@@ -50,9 +50,10 @@ class DefaultConfig(object):
     CLOUDFRONT_BASE_URL = "https://d3bhweee2a5al5.cloudfront.net"
 
     # endpoint of the signing service
-    SIGNING_SERVICE_URL = "http://127.0.0.1:8000/signature"
+    SIGNING_SERVICE_URL = "http://127.0.0.1:8000/sign/hash"
     SIGNING_HAWK_ID = "alice"
     SIGNING_HAWK_KEY = "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu"
+    SIGNING_TEMPLATE = "Content-Signature:\x00"
 
     LOG_HANDLERS = {
         'application': {

--- a/splice/web/api/content_upload.py
+++ b/splice/web/api/content_upload.py
@@ -141,6 +141,9 @@ def _digest_content(content):
         Where signature_dict has two keys: "encrypted key" and "signature".
         If the asset is not in the manifest, signature_dict will be None.
     """
+    def _prepend_template(content):
+        return "%s%s" % (env.config.SIGNING_TEMPLATE, content)
+
     with zipfile.ZipFile(content, 'r') as zf:
         all_assets = set([n for n in zf.namelist() if n[-1] != '/'])
 
@@ -160,7 +163,7 @@ def _digest_content(content):
 
             # the content payload reference: https://github.com/mozilla-services/autograph
             # digest() is intentionally used for signature verifying
-            hash = hashlib.sha384(zf.read(s)).digest()
+            hash = hashlib.sha384(_prepend_template(zf.read(s))).digest()
             payload = {
                 "input": "%s" % base64.b64encode(hash),
             }


### PR DESCRIPTION
Added two changes to catch up with Autograph:
- update the signing service endpoint from `signature` to `sign/hash`
- prepend a template for each raw content prior to hashing it

Also, we've added the bookkeeping for the signing public key, as Autograph always includes it in the signature payload. 
