### PR TITLE
Tweak the Ping-Centre schema after stage test

### DIFF
--- a/ddl/migrations/redshift/1487106710.sql
+++ b/ddl/migrations/redshift/1487106710.sql
@@ -1,5 +1,9 @@
 BEGIN;
 
+DROP TABLE IF EXISTS ping_centre_test_pilot;
+DROP TABLE IF EXISTS activity_stream_mobile_events_daily;
+DROP TABLE IF EXISTS activity_stream_mobile_stats_daily;
+
 CREATE TABLE ping_centre_test_pilot (
     client_id VARCHAR(64) NOT NULL, 
     event_type VARCHAR(64) NOT NULL, 
@@ -14,7 +18,7 @@ CREATE TABLE ping_centre_test_pilot (
     os_name VARCHAR(64) NOT NULL, 
     os_version VARCHAR(64) NOT NULL, 
     locale VARCHAR(14) NOT NULL, 
-    "raw" VARCHAR(16384) NOT NULL
+    raw_ping VARCHAR(16384) NOT NULL
 );
 
 CREATE TABLE activity_stream_mobile_events_daily (
@@ -24,6 +28,7 @@ CREATE TABLE activity_stream_mobile_events_daily (
     page VARCHAR(64) NOT NULL, 
     action_position VARCHAR(16), 
     source VARCHAR(64), 
+    release_channel VARCHAR(32),
     event VARCHAR(64) NOT NULL, 
     receive_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
     date DATE NOT NULL, 
@@ -40,6 +45,7 @@ CREATE TABLE activity_stream_mobile_stats_daily (
     build VARCHAR(64) NOT NULL, 
     app_version VARCHAR(64) NOT NULL, 
     session_duration INTEGER NOT NULL, 
+    release_channel VARCHAR(32),
     receive_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, 
     date DATE NOT NULL, 
     locale VARCHAR(14) NOT NULL, 

--- a/migrations/versions/3473e3069558_.py
+++ b/migrations/versions/3473e3069558_.py
@@ -58,7 +58,7 @@ def upgrade_stats():
     sa.Column('os_name', sa.String(length=64), nullable=False),
     sa.Column('os_version', sa.String(length=64), nullable=False),
     sa.Column('locale', sa.String(length=14), nullable=False),
-    sa.Column('raw', sa.String(length=16384), nullable=False)
+    sa.Column('raw_ping', sa.String(length=16384), nullable=False)
     )
     op.create_table('activity_stream_mobile_events_daily',
     sa.Column('client_id', sa.String(length=64), nullable=False),
@@ -67,6 +67,7 @@ def upgrade_stats():
     sa.Column('page', sa.String(length=64), nullable=False),
     sa.Column('action_position', sa.String(length=16), nullable=True),
     sa.Column('source', sa.String(length=64), nullable=True),
+    sa.Column('release_channel', sa.String(length=32), nullable=True),
     sa.Column('event', sa.String(length=64), nullable=False),
     sa.Column('receive_at', sa.DateTime(), nullable=False),
     sa.Column('date', sa.Date(), nullable=False),
@@ -82,6 +83,7 @@ def upgrade_stats():
     sa.Column('build', sa.String(length=64), nullable=False),
     sa.Column('app_version', sa.String(length=64), nullable=False),
     sa.Column('session_duration', sa.Integer(), nullable=False),
+    sa.Column('release_channel', sa.String(length=32), nullable=True),
     sa.Column('receive_at', sa.DateTime(), nullable=False),
     sa.Column('date', sa.Date(), nullable=False),
     sa.Column('locale', sa.String(length=14), nullable=False),

--- a/splice/models.py
+++ b/splice/models.py
@@ -329,7 +329,7 @@ ping_centre_test_pilot = db.Table(
     db.Column('os_name', db.String(64), nullable=False),
     db.Column('os_version', db.String(64), nullable=False),
     db.Column('locale', db.String(14), nullable=False),
-    db.Column('raw', db.String(16384), nullable=False),
+    db.Column('raw_ping', db.String(16384), nullable=False),
     info={'bind_key': 'stats'}
 )
 
@@ -339,6 +339,7 @@ activity_stream_mobile_stats_daily = db.Table(
     db.Column('build', db.String(64), nullable=False),
     db.Column('app_version', db.String(64), nullable=False),
     db.Column('session_duration', db.Integer, nullable=False),
+    db.Column('release_channel', db.String(32)),
     db.Column('receive_at', db.DateTime, nullable=False),
     db.Column('date', db.Date, nullable=False),
     db.Column('locale', db.String(14), nullable=False),
@@ -358,6 +359,7 @@ activity_stream_mobile_events_daily = db.Table(
     db.Column('page', db.String(64), nullable=False),
     db.Column('action_position', db.String(16)),
     db.Column('source', db.String(64)),
+    db.Column('release_channel', db.String(32)),
     db.Column('event', db.String(64), nullable=False),
     db.Column('receive_at', db.DateTime, nullable=False),
     db.Column('date', db.Date, nullable=False),


### PR DESCRIPTION
This includes two table schema changes after the first Ping-Centre test in stage.

* Rename the "raw" column to "raw_ping" to avoid keyword collision
* Add "release_channel" for the A-S mobile as required