### PR TITLE
Update signing protocol for autograph

### DIFF
--- a/splice/default_settings.py
+++ b/splice/default_settings.py
@@ -54,6 +54,7 @@ class DefaultConfig(object):
     SIGNING_HAWK_ID = "alice"
     SIGNING_HAWK_KEY = "fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu"
     SIGNING_TEMPLATE = "Content-Signature:\x00"
+    SIGNING_KEY_ID = "normankey"
 
     LOG_HANDLERS = {
         'application': {

--- a/splice/web/api/content_upload.py
+++ b/splice/web/api/content_upload.py
@@ -261,7 +261,7 @@ def _extract_entryption_info(signature_dict):
     Reference: https://github.com/mozilla-services/autograph
     """
     encrypt_key = signature_dict.get("public_key")  # signing server might not send pub key
-    signature = signature_dict["content-signature"]
+    signature = signature_dict["signature"]
     return encrypt_key, signature
 
 

--- a/tests/api/test_content.py
+++ b/tests/api/test_content.py
@@ -40,7 +40,8 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload """
         dummy_signature = {
             "public_key": "somerandomkey",
-            "signature": "somesignature"
+            "signature": "somesignature",
+            "x5u": "somex5u"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -77,7 +78,8 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload - re-sign a content"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "signature": "somesignature"
+            "signature": "somesignature",
+            "x5u": "somex5u"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -100,7 +102,8 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload - sign an existing content"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "signature": "somesignature"
+            "signature": "somesignature",
+            "x5u": "somex5u"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -126,7 +129,8 @@ class TestContent(BaseTestCase):
     def test_upload_content_endpoint_sign_existing_without_bumping_version(self, s3Mock, signMock, verifyMock):
         dummy_signature = {
             "public_key": "somerandomkey",
-            "signature": "somesignature"
+            "signature": "somesignature",
+            "x5u": "somex5u"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -271,7 +275,8 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content resign all"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "signature": "somesignature"
+            "signature": "somesignature",
+            "x5u": "somex5u"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -323,7 +328,8 @@ class TestContent(BaseTestCase):
         signature_dict = {
             'public_key': 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6',
             'ref': '51frsk7tsnx42s0cwo9rbc99r',
-            'signature': 'haRzzBXgPEpe9050ybZMIxFoQS3gcESzqxLBYU2SRVEyolnTD815U5NQ4JO2jGanOSqcAbmJUuo1ceSC9p8xFjrCuWU8mEemcRPdNGzu1b3T3tE-SYuANQpaZVBfuy1B'
+            'signature': 'haRzzBXgPEpe9050ybZMIxFoQS3gcESzqxLBYU2SRVEyolnTD815U5NQ4JO2jGanOSqcAbmJUuo1ceSC9p8xFjrCuWU8mEemcRPdNGzu1b3T3tE-SYuANQpaZVBfuy1B',
+            'x5u': 'https://foo.example.com/chains/certificates.pem'
         }
         ret = content_upload._verify_signature(sign_payload, signature_dict)
         self.assertTrue(ret)

--- a/tests/api/test_content.py
+++ b/tests/api/test_content.py
@@ -40,7 +40,7 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload """
         dummy_signature = {
             "public_key": "somerandomkey",
-            "content-signature": "somesignature"
+            "signature": "somesignature"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -77,7 +77,7 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload - re-sign a content"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "content-signature": "somesignature"
+            "signature": "somesignature"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -100,7 +100,7 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content upload - sign an existing content"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "content-signature": "somesignature"
+            "signature": "somesignature"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -126,7 +126,7 @@ class TestContent(BaseTestCase):
     def test_upload_content_endpoint_sign_existing_without_bumping_version(self, s3Mock, signMock, verifyMock):
         dummy_signature = {
             "public_key": "somerandomkey",
-            "content-signature": "somesignature"
+            "signature": "somesignature"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -271,7 +271,7 @@ class TestContent(BaseTestCase):
         """Test the API endpoint for the content resign all"""
         dummy_signature = {
             "public_key": "somerandomkey",
-            "content-signature": "somesignature"
+            "signature": "somesignature"
         }
         signMock.return_value = [dummy_signature] * 4  # four files in the manifest
         s3Mock.return_value = "http://bucket/content"
@@ -322,7 +322,6 @@ class TestContent(BaseTestCase):
         }
         signature_dict = {
             'public_key': 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6',
-            'content-signature': 'keyid=appkey1; p384ecdsa=haRzzBXgPEpe9050ybZMIxFoQS3gcESzqxLBYU2SRVEyolnTD815U5NQ4JO2jGanOSqcAbmJUuo1ceSC9p8xFjrCuWU8mEemcRPdNGzu1b3T3tE-SYuANQpaZVBfuy1B',
             'ref': '51frsk7tsnx42s0cwo9rbc99r',
             'signature': 'haRzzBXgPEpe9050ybZMIxFoQS3gcESzqxLBYU2SRVEyolnTD815U5NQ4JO2jGanOSqcAbmJUuo1ceSC9p8xFjrCuWU8mEemcRPdNGzu1b3T3tE-SYuANQpaZVBfuy1B'
         }


### PR DESCRIPTION
This adapts the new signing protocol of [Autograph](https://github.com/mozilla-services/autograph)

* Add `keyid` to the signing request in order to let Autograpy generate `x5u` field in the response. See more detail [here](https://github.com/mozilla-services/autograph/blob/master/docs/endpoints.rst#11request)
* Extract `x5u` from the response so that it can be used when verifying the signature in Firefox. See more detail [here](https://github.com/mozilla-services/autograph/blob/master/docs/endpoints.rst#12response)